### PR TITLE
fix: Correct hologram module path in examples

### DIFF
--- a/v2.0/examples/advanced_config.py
+++ b/v2.0/examples/advanced_config.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 # Add hologram to path
-hologram_path = Path.home() / "hologram-cognitive/hologram"
+hologram_path = Path.home() / "hologram-cognitive"
 sys.path.insert(0, str(hologram_path))
 
 from hologram import HologramRouter, InjectionConfig

--- a/v2.0/examples/basic_usage.py
+++ b/v2.0/examples/basic_usage.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 # Add hologram to path
-hologram_path = Path.home() / "hologram-cognitive/hologram"
+hologram_path = Path.home() / "hologram-cognitive"
 sys.path.insert(0, str(hologram_path))
 
 from hologram import HologramRouter


### PR DESCRIPTION
The path should reference the parent directory (hologram-cognitive/) not the module directory (hologram-cognitive/hologram/) to properly import the hologram module.

Fixes #13